### PR TITLE
Fix RollUp Mac ARM issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,27 +1,30 @@
-version: '3.8'
 services:
   backend:
+    # For architecture change (not available for Podman)
+    # platform: linux/arm64/v8
     build:
-      context: ./Backend
+      context: ./backend
       dockerfile: Dockerfile
     volumes:
-      - ./Backend:/app
+      - ./backend:/app
     ports:
-      - "8000:8000"
+      - 8000:8000
     networks:
       - app-network
     restart: unless-stopped
     environment:
       - CHOKIDAR_USEPOLLING=true
-
   frontend:
+    # For architecture change (not available for Podman)
+    # platform: linux/arm64/v8
     build:
-      context: ./Frontend
+      context: ./frontend
       dockerfile: Dockerfile
     ports:
-      - "4200:4200"
+      - 4200:4200
+    # Avoid dev rebuilds
     volumes:
-      - ./Frontend:/app  # Monta el frontend completo, pero ignora node_modules
+      - ./frontend:/app
     networks:
       - app-network
     restart: unless-stopped

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,24 +1,16 @@
 # Base image
-FROM node:18.19
+FROM docker.io/library/node:20.17
 
 # Set working directory
 WORKDIR /app
 
-# Add `/app/node_modules/.bin` to $PATH
-ENV PATH /app/node_modules/.bin:$PATH
-
-# Copy package.json and package-lock.json (if it exists)
-COPY package.json /app/package.json
-COPY package-lock.json /app/package-lock.json
+COPY package.json package-lock.json* ./
 
 # Install dependencies
-RUN npm install
-
-# Install Angular CLI (más actualizado)
-RUN npm install -g @angular/cli@18.0.0
+RUN npm ci --retry=5 && npm install -g @angular/cli@18.2.3 --retry=5 && npm cache clean --force
 
 # Copy all app files
 COPY . /app
 
 # Expose port and start the app
-CMD ng serve --host 0.0.0.0 --disable-host-check
+CMD ["ng", "serve", "--host", "0.0.0.0", "--disable-host-check"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boatco2",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -43,5 +43,10 @@
     "karma-jasmine-html-reporter": "~2.1.0",
     "typescript": "~5.5.2",
     "vite": "^5.4.3"
+  },
+  "overrides": {
+    "vite": {
+      "rollup": "npm:@rollup/wasm-node"
+    }
   }
 }


### PR DESCRIPTION
- Bump up Node version to LTS
- Change Vite Rollup configuration to WASM
- Update Docker compose file to reflect the actual setup

Explanation:
ARM arch seems to use WASM Node versions as answered in the issue below:

https://github.com/vitejs/vite/issues/15167